### PR TITLE
Modification to return logit in inference_small()

### DIFF
--- a/resnet.py
+++ b/resnet.py
@@ -101,8 +101,11 @@ def inference_small(x,
     c['fc_units_out'] = num_classes
     c['num_blocks'] = num_blocks
     c['num_classes'] = num_classes
-    inference_small_config(x, c)
+    x = inference_small_config(x, c)
 
+    return x
+    
+    
 def inference_small_config(x, c):
     c['bottleneck'] = False
     c['ksize'] = 3


### PR DESCRIPTION
I found the missing line for returning logit of `inference_small()`.
I added the line at the end of `inference_small()`.
